### PR TITLE
Add Death game page with Play page routing

### DIFF
--- a/client/components/layout/layout-header.tsx
+++ b/client/components/layout/layout-header.tsx
@@ -35,9 +35,9 @@ function LayoutHeader() {
           {/* Navigation */}
           <nav className="hidden md:flex items-center gap-8">
             <Link
-              to="/"
+              to="/play"
               className={`text-sm transition-colors ${
-                isActiveRoute("/")
+                isActiveRoute("/play")
                   ? "text-neon-blue"
                   : "text-muted-foreground hover:text-neon-blue"
               }`}

--- a/client/pages/Death.tsx
+++ b/client/pages/Death.tsx
@@ -30,7 +30,9 @@ export default function Death() {
           <div className="glass-morphism rounded-xl p-6 border border-neon-purple/30">
             <div className="flex items-center justify-between mb-6">
               <div>
-                <h2 className="text-2xl font-bold text-neon-purple mb-2">Game Over</h2>
+                <h2 className="text-2xl font-bold text-neon-purple mb-2">
+                  Game Over
+                </h2>
                 <p className="text-muted-foreground">You hit a trap</p>
               </div>
               <div className="text-right">
@@ -46,7 +48,9 @@ export default function Death() {
                 <div
                   key={i}
                   className={`flex items-center gap-4 px-3 py-4 rounded-xl ${
-                    i === 4 ? "border-4 border-neon-green/80" : "border border-game-grid"
+                    i === 4
+                      ? "border-4 border-neon-green/80"
+                      : "border border-game-grid"
                   } bg-game-surface`}
                 >
                   <div className="w-12 text-left text-sm text-muted-foreground">
@@ -57,11 +61,15 @@ export default function Death() {
                       <div
                         key={tIdx}
                         className={`h-12 rounded flex items-center justify-center ${
-                          tile.highlighted ? "bg-neon-green" : "bg-game-tile border border-game-grid"
+                          tile.highlighted
+                            ? "bg-neon-green"
+                            : "bg-game-tile border border-game-grid"
                         }`}
                       >
                         {tile.hasSkull ? (
-                          <span className={`${tile.highlighted ? "text-black" : "text-white"} text-xl`}>
+                          <span
+                            className={`${tile.highlighted ? "text-black" : "text-white"} text-xl`}
+                          >
                             ☠️
                           </span>
                         ) : null}
@@ -80,10 +88,13 @@ export default function Death() {
                 {""}
               </p>
               <div className="flex gap-3 justify-center mt-2">
-                <Button onClick={() => navigate('/play')} className="bg-neon-green hover:bg-neon-green/90 text-black neon-glow">
+                <Button
+                  onClick={() => navigate("/play")}
+                  className="bg-neon-green hover:bg-neon-green/90 text-black neon-glow"
+                >
                   Retry
                 </Button>
-                <Button variant="outline" onClick={() => navigate('/')}>
+                <Button variant="outline" onClick={() => navigate("/")}>
                   Home
                 </Button>
               </div>
@@ -100,7 +111,14 @@ export default function Death() {
               1.58 x
             </div>
             <div className="ml-3 w-8 h-8 rounded-full border border-game-grid flex items-center justify-center">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
                 <circle cx="12" cy="12" r="10" />
                 <path d="M9 12l2 2 4-4" />
               </svg>
@@ -121,12 +139,22 @@ export default function Death() {
           <div className="flex items-center gap-3 mb-4">
             <div className="flex-1">
               <div className="rounded-lg border border-neon-green p-1 flex items-center gap-2">
-                <button className="px-4 py-2 rounded-full bg-neon-green text-black font-semibold">.001</button>
-                <button className="px-4 py-2 rounded-full text-muted-foreground">.01</button>
-                <button className="px-4 py-2 rounded-full text-muted-foreground">.1</button>
-                <button className="px-4 py-2 rounded-full text-muted-foreground">1</button>
+                <button className="px-4 py-2 rounded-full bg-neon-green text-black font-semibold">
+                  .001
+                </button>
+                <button className="px-4 py-2 rounded-full text-muted-foreground">
+                  .01
+                </button>
+                <button className="px-4 py-2 rounded-full text-muted-foreground">
+                  .1
+                </button>
+                <button className="px-4 py-2 rounded-full text-muted-foreground">
+                  1
+                </button>
               </div>
-              <div className="text-xs text-muted-foreground mt-2">0.0046 ETH / CUSTOM BET</div>
+              <div className="text-xs text-muted-foreground mt-2">
+                0.0046 ETH / CUSTOM BET
+              </div>
             </div>
 
             <div>
@@ -137,7 +165,9 @@ export default function Death() {
           </div>
 
           <div className="mb-2">
-            <Button className="w-full bg-neon-green text-black neon-glow py-4 text-lg font-bold">Retry</Button>
+            <Button className="w-full bg-neon-green text-black neon-glow py-4 text-lg font-bold">
+              Retry
+            </Button>
           </div>
 
           <div className="flex justify-end">

--- a/client/pages/Death.tsx
+++ b/client/pages/Death.tsx
@@ -24,47 +24,77 @@ export default function Death() {
   }));
 
   return (
-    <div className="min-h-screen bg-game-bg flex flex-col">
-      <div className="flex-1 overflow-auto p-4">
-        <div className="max-w-md mx-auto">
-          <div className="space-y-4">
-            {rows.map((row, i) => (
-              <div
-                key={i}
-                className={`flex items-center gap-4 px-3 py-4 rounded-xl ${
-                  i === 4 ? "border-4 border-neon-green/80" : "border border-game-grid"
-                } bg-game-surface`}
-              >
-                <div className="w-12 text-left text-sm text-muted-foreground">
-                  {row.multiplier.toFixed(2)}x
-                </div>
-                <div className="flex-1 grid grid-cols-6 gap-3">
-                  {row.tiles.map((tile, tIdx) => (
-                    <div
-                      key={tIdx}
-                      className={`h-12 rounded flex items-center justify-center ${
-                        tile.highlighted
-                          ? "bg-neon-green"
-                          : "bg-game-tile border border-game-grid"
-                      }`}
-                    >
-                      {tile.hasSkull ? (
-                        <span className={`${tile.highlighted ? "text-black" : "text-white"} text-xl`}>
-                          ☠️
-                        </span>
-                      ) : null}
-                    </div>
-                  ))}
-                </div>
+    <div className="min-h-screen bg-game-bg">
+      <div className="container mx-auto px-6 pt-8 pb-6">
+        <div className="max-w-4xl mx-auto">
+          <div className="glass-morphism rounded-xl p-6 border border-neon-purple/30">
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h2 className="text-2xl font-bold text-neon-purple mb-2">Game Over</h2>
+                <p className="text-muted-foreground">You hit a trap</p>
               </div>
-            ))}
+              <div className="text-right">
+                <p className="text-sm text-muted-foreground">Lost</p>
+                <p className="text-xl font-bold text-neon-orange">
+                  {lost ? `${lost.toFixed(4)} ETH` : "—"}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              {rows.map((row, i) => (
+                <div
+                  key={i}
+                  className={`flex items-center gap-4 px-3 py-4 rounded-xl ${
+                    i === 4 ? "border-4 border-neon-green/80" : "border border-game-grid"
+                  } bg-game-surface`}
+                >
+                  <div className="w-12 text-left text-sm text-muted-foreground">
+                    {row.multiplier.toFixed(2)}x
+                  </div>
+                  <div className="flex-1 grid grid-cols-6 gap-3">
+                    {row.tiles.map((tile, tIdx) => (
+                      <div
+                        key={tIdx}
+                        className={`h-12 rounded flex items-center justify-center ${
+                          tile.highlighted ? "bg-neon-green" : "bg-game-tile border border-game-grid"
+                        }`}
+                      >
+                        {tile.hasSkull ? (
+                          <span className={`${tile.highlighted ? "text-black" : "text-white"} text-xl`}>
+                            ☠️
+                          </span>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-6 p-4 bg-game-surface rounded-lg border border-game-grid text-center">
+              <p className="text-lg font-medium">
+                {""}
+                {"\n"}
+                {"\n"}
+                {""}
+              </p>
+              <div className="flex gap-3 justify-center mt-2">
+                <Button onClick={() => navigate('/play')} className="bg-neon-green hover:bg-neon-green/90 text-black neon-glow">
+                  Retry
+                </Button>
+                <Button variant="outline" onClick={() => navigate('/')}>
+                  Home
+                </Button>
+              </div>
+            </div>
           </div>
         </div>
       </div>
 
-      {/* Bottom Controls */}
+      {/* Bottom Controls matching Play style */}
       <div className="border-t border-game-grid bg-game-surface p-4 sticky bottom-0">
-        <div className="max-w-md mx-auto">
+        <div className="container mx-auto px-6 max-w-4xl">
           <div className="flex items-center justify-center mb-4">
             <div className="px-6 py-2 bg-neon-green rounded-full text-black font-bold text-lg">
               1.58 x
@@ -107,7 +137,7 @@ export default function Death() {
           </div>
 
           <div className="mb-2">
-            <Button className="w-full bg-neon-green text-black neon-glow py-4 text-lg font-bold">Start</Button>
+            <Button className="w-full bg-neon-green text-black neon-glow py-4 text-lg font-bold">Retry</Button>
           </div>
 
           <div className="flex justify-end">

--- a/client/pages/Death.tsx
+++ b/client/pages/Death.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { useLocation, useNavigate } from "react-router-dom";
+import { Shuffle, Volume } from "lucide-react";
 
 export default function Death() {
   const location = useLocation();
@@ -14,28 +15,106 @@ export default function Death() {
     return q ? parseFloat(q) : undefined;
   }, [location]);
 
+  const rows = Array.from({ length: 6 }).map((_, idx) => ({
+    multiplier: [3.32, 2.65, 2.21, 1.84, 1.58, 1.26][idx] ?? 1 + idx * 0.1,
+    tiles: Array.from({ length: 6 }).map((__, t) => ({
+      hasSkull: Math.random() < (t === 2 && idx === 4 ? 1 : 0.15),
+      highlighted: idx === 4 && t === 4,
+    })),
+  }));
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-game-bg p-6">
-      <div className="max-w-md w-full glass-morphism rounded-xl p-8 border border-game-grid text-center">
-        <div className="mb-4">
-          <div className="text-6xl">💀</div>
+    <div className="min-h-screen bg-game-bg flex flex-col">
+      <div className="flex-1 overflow-auto p-4">
+        <div className="max-w-md mx-auto">
+          <div className="space-y-4">
+            {rows.map((row, i) => (
+              <div
+                key={i}
+                className={`flex items-center gap-4 px-3 py-4 rounded-xl ${
+                  i === 4 ? "border-4 border-neon-green/80" : "border border-game-grid"
+                } bg-game-surface`}
+              >
+                <div className="w-12 text-left text-sm text-muted-foreground">
+                  {row.multiplier.toFixed(2)}x
+                </div>
+                <div className="flex-1 grid grid-cols-6 gap-3">
+                  {row.tiles.map((tile, tIdx) => (
+                    <div
+                      key={tIdx}
+                      className={`h-12 rounded flex items-center justify-center ${
+                        tile.highlighted
+                          ? "bg-neon-green"
+                          : "bg-game-tile border border-game-grid"
+                      }`}
+                    >
+                      {tile.hasSkull ? (
+                        <span className={`${tile.highlighted ? "text-black" : "text-white"} text-xl`}>
+                          ☠️
+                        </span>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
-        <h1 className="text-2xl font-bold text-neon-orange mb-2">Game Over</h1>
-        <p className="text-sm text-muted-foreground mb-4">
-          You hit a trap and lost {lost ? `${lost.toFixed(4)} ETH` : "your bet"}.
-        </p>
+      </div>
 
-        <div className="flex gap-3 justify-center">
-          <Button onClick={() => navigate('/play')} className="bg-neon-green text-black neon-glow">
-            Retry
-          </Button>
-          <Button variant="outline" onClick={() => navigate('/')}>
-            Home
-          </Button>
-        </div>
+      {/* Bottom Controls */}
+      <div className="border-t border-game-grid bg-game-surface p-4 sticky bottom-0">
+        <div className="max-w-md mx-auto">
+          <div className="flex items-center justify-center mb-4">
+            <div className="px-6 py-2 bg-neon-green rounded-full text-black font-bold text-lg">
+              1.58 x
+            </div>
+            <div className="ml-3 w-8 h-8 rounded-full border border-game-grid flex items-center justify-center">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M9 12l2 2 4-4" />
+              </svg>
+            </div>
+          </div>
 
-        <div className="mt-6 text-xs text-muted-foreground">
-          Tip: You can cash out early in future rounds to secure winnings.
+          <div className="flex items-center justify-center gap-6 text-sm text-neon-green mb-4">
+            <div className="flex items-center gap-2">
+              <div className="text-neon-green">♦</div>
+              <div className="text-white">0.0016</div>
+            </div>
+            <div className="flex items-center gap-2">
+              <div>😵</div>
+              <div className="text-white">+0.23</div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex-1">
+              <div className="rounded-lg border border-neon-green p-1 flex items-center gap-2">
+                <button className="px-4 py-2 rounded-full bg-neon-green text-black font-semibold">.001</button>
+                <button className="px-4 py-2 rounded-full text-muted-foreground">.01</button>
+                <button className="px-4 py-2 rounded-full text-muted-foreground">.1</button>
+                <button className="px-4 py-2 rounded-full text-muted-foreground">1</button>
+              </div>
+              <div className="text-xs text-muted-foreground mt-2">0.0046 ETH / CUSTOM BET</div>
+            </div>
+
+            <div>
+              <button className="w-12 h-12 bg-white rounded-lg flex items-center justify-center shadow">
+                <Shuffle className="w-5 h-5 text-black" />
+              </button>
+            </div>
+          </div>
+
+          <div className="mb-2">
+            <Button className="w-full bg-neon-green text-black neon-glow py-4 text-lg font-bold">Start</Button>
+          </div>
+
+          <div className="flex justify-end">
+            <button className="p-2 text-muted-foreground">
+              <Volume className="w-5 h-5" />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/client/pages/Death.tsx
+++ b/client/pages/Death.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { useLocation, useNavigate } from "react-router-dom";
+
+export default function Death() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const lost = useMemo(() => {
+    const stateLost = (location.state as any)?.lost;
+    if (typeof stateLost === "number") return stateLost;
+    const params = new URLSearchParams(location.search);
+    const q = params.get("lost");
+    return q ? parseFloat(q) : undefined;
+  }, [location]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-game-bg p-6">
+      <div className="max-w-md w-full glass-morphism rounded-xl p-8 border border-game-grid text-center">
+        <div className="mb-4">
+          <div className="text-6xl">💀</div>
+        </div>
+        <h1 className="text-2xl font-bold text-neon-orange mb-2">Game Over</h1>
+        <p className="text-sm text-muted-foreground mb-4">
+          You hit a trap and lost {lost ? `${lost.toFixed(4)} ETH` : "your bet"}.
+        </p>
+
+        <div className="flex gap-3 justify-center">
+          <Button onClick={() => navigate('/play')} className="bg-neon-green text-black neon-glow">
+            Retry
+          </Button>
+          <Button variant="outline" onClick={() => navigate('/')}>
+            Home
+          </Button>
+        </div>
+
+        <div className="mt-6 text-xs text-muted-foreground">
+          Tip: You can cash out early in future rounds to secure winnings.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/pages/Play.tsx
+++ b/client/pages/Play.tsx
@@ -1,0 +1,9 @@
+import { Dashboard } from "@/components/Dashboard";
+
+export default function Play() {
+  return (
+    <div className="min-h-screen bg-game-bg">
+      <Dashboard />
+    </div>
+  );
+}

--- a/client/routes.tsx
+++ b/client/routes.tsx
@@ -1,6 +1,7 @@
 import { createRef } from "react";
 import Index from "./pages/Index";
 import Play from "@/pages/Play";
+import Death from "@/pages/Death";
 import Staking from "@/pages/Staking";
 import Leaderboard from "@/pages/Leaderboard";
 import Referral from "@/pages/Referral";

--- a/client/routes.tsx
+++ b/client/routes.tsx
@@ -22,6 +22,12 @@ export const routes = [
     name: "Play",
   },
   {
+    path: "/death",
+    element: <Death />,
+    nodeRef: createRef(),
+    name: "Death",
+  },
+  {
     path: "/staking",
     element: <Staking />,
     nodeRef: createRef(),

--- a/client/routes.tsx
+++ b/client/routes.tsx
@@ -1,5 +1,6 @@
 import { createRef } from "react";
 import Index from "./pages/Index";
+import Play from "@/pages/Play";
 import Staking from "@/pages/Staking";
 import Leaderboard from "@/pages/Leaderboard";
 import Referral from "@/pages/Referral";
@@ -12,6 +13,12 @@ export const routes = [
     element: <Index />,
     nodeRef: createRef(),
     name: "Home",
+  },
+  {
+    path: "/play",
+    element: <Play />,
+    nodeRef: createRef(),
+    name: "Play",
   },
   {
     path: "/staking",

--- a/package.json
+++ b/package.json
@@ -99,5 +99,6 @@
     "vaul": "^0.9.3",
     "vite": "^6.2.2",
     "vitest": "^3.1.4"
-  }
+  },
+  "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a"
 }


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user wanted to create a new game page called "Death" that follows the same styling and configuration as the existing Play page. The goal was to add a game-over screen that displays when players hit a trap, with consistent visual design and navigation.

## Code changes

- **Added new Death page** (`client/pages/Death.tsx`): Created a comprehensive game-over screen with:
  - Game grid display showing multipliers and trap locations
  - Loss amount display in ETH
  - Retry and navigation buttons
  - Bottom controls matching Play page styling
  - Glass morphism design with neon color scheme

- **Added new Play page** (`client/pages/Play.tsx`): Simple wrapper component that renders the Dashboard component

- **Updated routing** (`client/routes.tsx`): Added routes for both `/play` and `/death` pages

- **Updated navigation** (`client/components/layout/layout-header.tsx`): Changed default navigation link from `/` to `/play`

- **Package manager update**: Added pnpm package manager specification

The Death page maintains visual consistency with the Play page using the same color scheme (neon-green, neon-purple, neon-orange) and styling patterns.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98c74f1cb0d14233a36d2b9b84816fa7/zenith-landing)

👀 [Preview Link](https://98c74f1cb0d14233a36d2b9b84816fa7-zenith-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98c74f1cb0d14233a36d2b9b84816fa7</projectId>-->
<!--<branchName>zenith-landing</branchName>-->