### PR TITLE
Add toggleable sidebar to layout header

### DIFF
--- a/client/components/layout/layout-header.tsx
+++ b/client/components/layout/layout-header.tsx
@@ -25,7 +25,9 @@ function LayoutHeader() {
             </div>
             <div>
               <h1 className="text-xl font-bold text-neon-purple">Zonic.Fun</h1>
-              <p className="text-xs text-muted-foreground">Decentralized Risk Game</p>
+              <p className="text-xs text-muted-foreground">
+                Decentralized Risk Game
+              </p>
             </div>
           </div>
 

--- a/client/components/layout/layout-header.tsx
+++ b/client/components/layout/layout-header.tsx
@@ -16,7 +16,7 @@ function LayoutHeader() {
         <div className="flex items-center justify-between gap-3">
           {/* Left: sidebar trigger + logo */}
           <div className="flex items-center gap-2 md:gap-3">
-            <SidebarTrigger className="md:hidden inline-flex" />
+            <SidebarTrigger className="inline-flex" />
             <div className="relative">
               <Sparkles className="w-8 h-8 text-neon-purple animate-float" />
               <div className="absolute inset-0 blur-sm">

--- a/client/components/layout/layout-header.tsx
+++ b/client/components/layout/layout-header.tsx
@@ -1,21 +1,22 @@
 import { WalletConnect } from "@/components/WalletConnect";
 import { Shield, Sparkles, Users } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 
 function LayoutHeader() {
   const location = useLocation();
 
   const isActiveRoute = (path: string) => {
-    console.log(location.pathname, path);
     return location.pathname === path;
   };
 
   return (
     <header className="border-b border-game-grid bg-game-surface/50 backdrop-blur-sm sticky top-0 z-50">
-      <div className="container mx-auto px-6 py-4">
-        <div className="flex items-center justify-between">
-          {/* Logo */}
-          <div className="flex items-center gap-3">
+      <div className="container mx-auto px-3 md:px-6 py-3 md:py-4">
+        <div className="flex items-center justify-between gap-3">
+          {/* Left: sidebar trigger + logo */}
+          <div className="flex items-center gap-2 md:gap-3">
+            <SidebarTrigger className="md:hidden inline-flex" />
             <div className="relative">
               <Sparkles className="w-8 h-8 text-neon-purple animate-float" />
               <div className="absolute inset-0 blur-sm">
@@ -23,12 +24,8 @@ function LayoutHeader() {
               </div>
             </div>
             <div>
-              <h1 className="text-xl font-bold text-neon-purple">
-                Zonic.Fun
-              </h1>
-              <p className="text-xs text-muted-foreground">
-                Decentralized Risk Game
-              </p>
+              <h1 className="text-xl font-bold text-neon-purple">Zonic.Fun</h1>
+              <p className="text-xs text-muted-foreground">Decentralized Risk Game</p>
             </div>
           </div>
 

--- a/client/components/layout/layout.tsx
+++ b/client/components/layout/layout.tsx
@@ -1,14 +1,110 @@
-import { useOutlet } from "react-router-dom";
 import LayoutHeader from "./layout-header";
 import LayoutFooter from "@/components/layout/layout-footer";
+import {
+  SidebarProvider,
+  Sidebar,
+  SidebarHeader,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarRail,
+  SidebarInset,
+  SidebarSeparator,
+} from "@/components/ui/sidebar";
+import { Link, useLocation } from "react-router-dom";
+import {
+  LayoutDashboard,
+  Gamepad2,
+  Trophy,
+  Users,
+  ShieldCheck,
+} from "lucide-react";
 
 function Layout({ children }: { children: React.ReactNode }) {
+  const location = useLocation();
+
+  const isActive = (path: string) => location.pathname === path;
+
   return (
-    <div className="">
-      <LayoutHeader />
-      <div className="">{children}</div>
-      <LayoutFooter />
-    </div>
+    <SidebarProvider>
+      <Sidebar collapsible="icon" className="bg-sidebar">
+        <SidebarHeader>
+          <Link to="/" className="flex items-center gap-2 px-2 py-1">
+            <span className="text-lg font-bold text-neon-purple">Zonic</span>
+          </Link>
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <Link to="/" className="contents">
+                  <SidebarMenuButton isActive={isActive("/")} tooltip="Home">
+                    <LayoutDashboard />
+                    <span>Home</span>
+                  </SidebarMenuButton>
+                </Link>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <Link to="/play" className="contents">
+                  <SidebarMenuButton isActive={isActive("/play")} tooltip="Play">
+                    <Gamepad2 />
+                    <span>Play</span>
+                  </SidebarMenuButton>
+                </Link>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <Link to="/staking" className="contents">
+                  <SidebarMenuButton
+                    isActive={isActive("/staking")}
+                    tooltip="Staking"
+                  >
+                    <ShieldCheck />
+                    <span>Staking</span>
+                  </SidebarMenuButton>
+                </Link>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <Link to="/leaderboard" className="contents">
+                  <SidebarMenuButton
+                    isActive={isActive("/leaderboard")}
+                    tooltip="Leaderboard"
+                  >
+                    <Trophy />
+                    <span>Leaderboard</span>
+                  </SidebarMenuButton>
+                </Link>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <Link to="/referral" className="contents">
+                  <SidebarMenuButton
+                    isActive={isActive("/referral")}
+                    tooltip="Referrals"
+                  >
+                    <Users />
+                    <span>Referrals</span>
+                  </SidebarMenuButton>
+                </Link>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarSeparator />
+        {/* Rail to click-collapse on desktop */}
+        <SidebarRail />
+      </Sidebar>
+
+      <SidebarInset>
+        <div className="flex min-h-svh flex-col">
+          <LayoutHeader />
+          <div className="flex-1">{children}</div>
+          <LayoutFooter />
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }
 

--- a/client/components/layout/layout.tsx
+++ b/client/components/layout/layout.tsx
@@ -50,7 +50,10 @@ function Layout({ children }: { children: React.ReactNode }) {
               </SidebarMenuItem>
               <SidebarMenuItem>
                 <Link to="/play" className="contents">
-                  <SidebarMenuButton isActive={isActive("/play")} tooltip="Play">
+                  <SidebarMenuButton
+                    isActive={isActive("/play")}
+                    tooltip="Play"
+                  >
                     <Gamepad2 />
                     <span>Play</span>
                   </SidebarMenuButton>


### PR DESCRIPTION
## Purpose

The user requested to edit the layout sidebar header to include a toggleable sidebar functionality. This enhancement improves navigation by providing a collapsible sidebar that users can show/hide as needed.

## Code changes

- **Layout restructure**: Wrapped the entire layout in `SidebarProvider` component to enable sidebar functionality
- **Sidebar implementation**: Added a new collapsible sidebar with navigation menu items (Home, Play, Staking, Leaderboard, Referrals) using appropriate icons
- **Header updates**: 
  - Added `SidebarTrigger` component to the header for toggling sidebar visibility
  - Adjusted header padding and spacing for better mobile responsiveness
  - Reorganized header layout to accommodate the sidebar trigger
- **Navigation enhancement**: Implemented active route highlighting in the sidebar menu
- **Responsive design**: Added responsive padding classes for better mobile/desktop experience
- **Code cleanup**: Removed debug console.log statement from route checking logicTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98c74f1cb0d14233a36d2b9b84816fa7/swoosh-realm)

👀 [Preview Link](https://98c74f1cb0d14233a36d2b9b84816fa7-swoosh-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98c74f1cb0d14233a36d2b9b84816fa7</projectId>-->
<!--<branchName>swoosh-realm</branchName>-->