### PR TITLE
Increase sidebar trigger and menu item sizes

### DIFF
--- a/client/components/ui/sidebar.tsx
+++ b/client/components/ui/sidebar.tsx
@@ -277,7 +277,7 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
-      className={cn("h-7 w-7", className)}
+      className={cn("h-10 w-10 [&>svg]:size-5", className)}
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
@@ -518,7 +518,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-3 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -527,10 +527,10 @@ const sidebarMenuButtonVariants = cva(
           "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
       },
       size: {
-        default: "h-8 text-sm",
-        sm: "h-7 text-xs",
-        lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0",
-        large: "h-14 text-lg group-data-[collapsible=icon]:!p-0",
+        default: "h-10 text-base",
+        sm: "h-8 text-sm [&>svg]:size-4",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0 [&>svg]:size-6",
+        large: "h-14 text-lg group-data-[collapsible=icon]:!p-0 [&>svg]:size-7",
       },
     },
     defaultVariants: {
@@ -668,7 +668,7 @@ const SidebarMenuSkeleton = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="menu-skeleton"
-      className={cn("rounded-md h-8 flex gap-2 px-2 items-center", className)}
+      className={cn("rounded-md h-10 flex gap-2 px-3 items-center", className)}
       {...props}
     >
       {showIcon && (


### PR DESCRIPTION
## Purpose

Improve the usability of the sidebar by increasing the size of sidebar items and the sidebar trigger button to make them easier to interact with.

## Code changes

- **SidebarTrigger**: Increased dimensions from `h-7 w-7` to `h-10 w-10` and set icon size to `size-5`
- **SidebarMenuButton**: Updated padding from `p-2` to `p-3` and increased icon size from `size-4` to `size-5`
- **Size variants**: Updated all size variants with larger heights and appropriate icon sizes:
  - `default`: `h-8` → `h-10`, `text-sm` → `text-base`
  - `sm`: `h-7` → `h-8`, added `[&>svg]:size-4`
  - `lg`: Added `[&>svg]:size-6`
  - `large`: Added `[&>svg]:size-7`
- **SidebarMenuSkeleton**: Increased height from `h-8` to `h-10` and padding from `px-2` to `px-3`To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/98c74f1cb0d14233a36d2b9b84816fa7/swoosh-sanctuary)

👀 [Preview Link](https://98c74f1cb0d14233a36d2b9b84816fa7-swoosh-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>98c74f1cb0d14233a36d2b9b84816fa7</projectId>-->
<!--<branchName>swoosh-sanctuary</branchName>-->